### PR TITLE
Change initialisation to accomodate testing

### DIFF
--- a/examples/aaq/faqmatches.py
+++ b/examples/aaq/faqmatches.py
@@ -1,5 +1,5 @@
 from api.aaq import pyAAQ
 
-faqmatches = pyAAQ.faqmatches.get_faqmatches()
+faqmatches = pyAAQ().faqmatches.get_faqmatches()
 
 faqmatches.head(5)

--- a/examples/aaq/faqranks.py
+++ b/examples/aaq/faqranks.py
@@ -1,7 +1,7 @@
 from api.aaq import pyAAQ
 
-faqranks = pyAAQ.inbounds.get_faqranks(
-    start_datetime="2023-01-01 00:00:00", end_datetime="2023-12-31 00:00:00"
+faqranks = pyAAQ().inbounds.get_faqranks(
+    start_datetime="2023-01-01 00:00:00", end_datetime="2023-02-01 00:00:00"
 )
 
 faqranks.head(5)

--- a/examples/aaq/inbounds.py
+++ b/examples/aaq/inbounds.py
@@ -1,7 +1,7 @@
 from api.aaq import pyAAQ
 
-inbounds = pyAAQ.inbounds.get_inbounds(
-    start_datetime="2023-01-01 00:00:00", end_datetime="2023-12-31 00:00:00"
+inbounds = pyAAQ().inbounds.get_inbounds(
+    start_datetime="2023-01-01 00:00:00", end_datetime="2023-02-01 00:00:00"
 )
 
 inbounds.head(5)

--- a/examples/aaq/inbounds_ud.py
+++ b/examples/aaq/inbounds_ud.py
@@ -1,7 +1,7 @@
 from api.aaq import pyAAQ
 
-inbounds_ud = pyAAQ.inbounds_ud.get_inbounds_ud(
-    start_datetime="2023-01-01 00:00:00", end_datetime="2023-12-31 00:00:00"
+inbounds_ud = pyAAQ().inbounds_ud.get_inbounds_ud(
+    start_datetime="2023-01-01 00:00:00", end_datetime="2023-02-01 00:00:00"
 )
 
 inbounds_ud.head(5)

--- a/examples/aaq/urgency_rules.py
+++ b/examples/aaq/urgency_rules.py
@@ -1,5 +1,5 @@
 from api.aaq import pyAAQ
 
-urgency_rules = pyAAQ.urgency_rules.get_urgency_rules()
+urgency_rules = pyAAQ().urgency_rules.get_urgency_rules()
 
 urgency_rules.head(5)

--- a/examples/content_repo/pages.py
+++ b/examples/content_repo/pages.py
@@ -1,5 +1,5 @@
 from api.content_repo import pyContent
 
-pages = pyContent.pages.get_pages()
+pages = pyContent().pages.get_pages()
 
 pages.head(5)

--- a/examples/content_repo/pageviews.py
+++ b/examples/content_repo/pageviews.py
@@ -4,6 +4,6 @@ from api.content_repo import pyContent
 
 start_time = datetime(2024, 1, 1).isoformat()
 
-pageviews = pyContent.pageviews.get_pageviews(ts=start_time)
+pageviews = pyContent().pageviews.get_pageviews(ts=start_time)
 
 pageviews.head(5)

--- a/examples/flow_results/flows.py
+++ b/examples/flow_results/flows.py
@@ -1,5 +1,5 @@
 from api.flow_results import pyFlows
 
-flows = pyFlows.flows.get_flows()
+flows = pyFlows().flows.get_flows()
 
 print(flows.keys())

--- a/examples/flow_results/responses.py
+++ b/examples/flow_results/responses.py
@@ -5,10 +5,10 @@ from api.flow_results import pyFlows
 now = datetime.now()
 
 end_time = now.isoformat()
-start_time = (now - timedelta(days=1)).isoformat()
-
-responses = pyFlows.responses.get_responses(start_time=start_time, end_time=end_time)
+start_time = (now - timedelta(days=0.05)).isoformat()
 
 print(f"Obtaining responses for dates: {start_time} to {end_time}.")
+
+responses = pyFlows().responses.get_responses(start_time=start_time, end_time=end_time)
 
 print(responses.keys())

--- a/examples/rapidpro/contacts.py
+++ b/examples/rapidpro/contacts.py
@@ -1,6 +1,6 @@
 from api.rapidpro import pyRapid
 
-contacts = pyRapid.contacts.get_contacts(
+contacts = pyRapid().contacts.get_contacts(
     before="2023-01-02 00:00:00", after="2023-01-01 00:00:00"
 )
 

--- a/examples/rapidpro/fields.py
+++ b/examples/rapidpro/fields.py
@@ -1,5 +1,5 @@
 from api.rapidpro import pyRapid
 
-fields = pyRapid.fields.get_fields()
+fields = pyRapid().fields.get_fields()
 
 fields.head(5)

--- a/examples/rapidpro/flows.py
+++ b/examples/rapidpro/flows.py
@@ -1,5 +1,5 @@
 from api.rapidpro import pyRapid
 
-flows = pyRapid.flows.get_flows()
+flows = pyRapid().flows.get_flows()
 
 flows.head(5)

--- a/examples/rapidpro/flowstarts.py
+++ b/examples/rapidpro/flowstarts.py
@@ -1,6 +1,6 @@
 from api.rapidpro import pyRapid
 
-flowstarts = pyRapid.flow_starts.get_flowstarts(
+flowstarts = pyRapid().flow_starts.get_flowstarts(
     before="2023-01-02 00:00:00", after="2023-01-01 00:00:00"
 )
 

--- a/examples/rapidpro/groups.py
+++ b/examples/rapidpro/groups.py
@@ -1,5 +1,5 @@
 from api.rapidpro import pyRapid
 
-groups = pyRapid.groups.get_groups()
+groups = pyRapid().groups.get_groups()
 
 groups.head(5)

--- a/examples/rapidpro/runs.py
+++ b/examples/rapidpro/runs.py
@@ -1,5 +1,7 @@
 from api.rapidpro import pyRapid
 
-runs = pyRapid.runs.get_runs(before="2024-10-01 04:00:00", after="2024-10-01 01:00:00")
+runs = pyRapid().runs.get_runs(
+    before="2024-10-01 01:30:00", after="2024-10-01 01:00:00"
+)
 
 runs.head(5)

--- a/examples/turn_bq/cards.py
+++ b/examples/turn_bq/cards.py
@@ -1,9 +1,9 @@
 from api.turn_bq import pyTurnBQ
 
-cards = pyTurnBQ.cards.get_cards()
+cards = pyTurnBQ().cards.get_cards()
 
 print(cards.head(5))
 
-cards_by_id = pyTurnBQ.cards.get_cards_by_id(card_id=817938)
+cards_by_id = pyTurnBQ().cards.get_cards_by_id(card_id=817938)
 
 print(cards_by_id)

--- a/examples/turn_bq/chats.py
+++ b/examples/turn_bq/chats.py
@@ -1,10 +1,10 @@
 from api.turn_bq import pyTurnBQ
 
-chats = pyTurnBQ.chats.get_chats_by_id(chat_id=1531207597)
+chats = pyTurnBQ().chats.get_chats_by_id(chat_id=1531207597)
 
 print(chats.head(5))
 
-chats = pyTurnBQ.chats.get_chats_by_updated_at(
+chats = pyTurnBQ().chats.get_chats_by_updated_at(
     from_timestamp="2023-10-01T00:00:00", to_timestamp="2023-10-10T00:00:00"
 )
 

--- a/examples/turn_bq/contacts.py
+++ b/examples/turn_bq/contacts.py
@@ -1,10 +1,10 @@
 from api.turn_bq import pyTurnBQ
 
-contacts = pyTurnBQ.contacts.get_contacts_by_id(contact_id=2350649091)
+contacts = pyTurnBQ().contacts.get_contacts_by_id(contact_id=2350649091)
 
 print(contacts.head(5))
 
-contacts = pyTurnBQ.contacts.get_contacts_by_updated_at(
+contacts = pyTurnBQ().contacts.get_contacts_by_updated_at(
     from_timestamp="2023-10-01T00:00:00", to_timestamp="2023-10-10T00:00:00"
 )
 

--- a/examples/turn_bq/flow_results.py
+++ b/examples/turn_bq/flow_results.py
@@ -1,12 +1,12 @@
 from api.turn_bq import pyTurnBQ
 
-flow_results = pyTurnBQ.flow_results.get_flow_results_by_id(
+flow_results = pyTurnBQ().flow_results.get_flow_results_by_id(
     stack_uuid="e060a3c1-d758-531f-b07b-9cc20895f572"
 )
 
 print(flow_results.head(5))
 
-flow_results = pyTurnBQ.flow_results.get_flow_results_by_updated_at(
+flow_results = pyTurnBQ().flow_results.get_flow_results_by_updated_at(
     from_timestamp="2023-10-01T00:00:00", to_timestamp="2023-10-10T00:00:00"
 )
 

--- a/examples/turn_bq/flow_results_data_packages.py
+++ b/examples/turn_bq/flow_results_data_packages.py
@@ -1,7 +1,7 @@
 from api.turn_bq import pyTurnBQ
 
 flow_results_data_packages = (
-    pyTurnBQ.flow_results_data_packages.get_flow_results_data_packages_by_id(
+    pyTurnBQ().flow_results_data_packages.get_flow_results_data_packages_by_id(
         stack_uuid="e6e2a502-c7f1-54c2-977e-fbe392a61bbf"
     )
 )
@@ -9,7 +9,7 @@ flow_results_data_packages = (
 print(flow_results_data_packages.head(5))
 
 flow_results_data_packages = (
-    pyTurnBQ.flow_results_data_packages.get_flow_results_data_packages_by_updated_at(  # noqa: E501
+    pyTurnBQ().flow_results_data_packages.get_flow_results_data_packages_by_updated_at(  # noqa: E501
         from_timestamp="2023-10-01T00:00:00", to_timestamp="2023-10-10T00:00:00"
     )
 )

--- a/examples/turn_bq/messages.py
+++ b/examples/turn_bq/messages.py
@@ -1,6 +1,6 @@
 from api.turn_bq import pyTurnBQ
 
-messages = pyTurnBQ.messages.get_messages_by_updated_at(
+messages = pyTurnBQ().messages.get_messages_by_updated_at(
     from_timestamp="2023-10-01T00:00:00", to_timestamp="2023-10-10T00:00:00"
 )
 

--- a/examples/turn_bq/statuses.py
+++ b/examples/turn_bq/statuses.py
@@ -1,6 +1,6 @@
 from api.turn_bq import pyTurnBQ
 
-statuses = pyTurnBQ.statuses.get_statuses_by_updated_at(
+statuses = pyTurnBQ().statuses.get_statuses_by_updated_at(
     from_timestamp="2023-10-01T00:00:00", to_timestamp="2023-10-10T00:00:00"
 )
 

--- a/rdw_ingestion_tools/api/aaq/main.py
+++ b/rdw_ingestion_tools/api/aaq/main.py
@@ -1,15 +1,31 @@
+from attrs import define, field
+from httpx import Client
+
 from api.aaq.requests.faqmatches import FAQMatches
 from api.aaq.requests.inbounds import Inbounds
 from api.aaq.requests.inbounds_ud import InboundsUD
 from api.aaq.requests.urgency_rules import UrgencyRules
 
-from . import client
+from . import client as default_client
 
 
+@define
 class pyAAQ:
-    """A wrapper class for the various AAQ endpoints."""
+    """A wrapper class for the various AAQ endpoints.
 
-    inbounds = Inbounds(client)
-    faqmatches = FAQMatches(client)
-    inbounds_ud = InboundsUD(client)
-    urgency_rules = UrgencyRules(client)
+    The client is configurable to it can be switched out in tests.
+
+    """
+
+    client: Client = field(factory=lambda: default_client)
+
+    inbounds = field(init=False)
+    faqmatches = field(init=False)
+    inbounds_ud = field(init=False)
+    urgency_rules = field(init=False)
+
+    def __attrs_post_init__(self):
+        self.inbounds = Inbounds(self.client)
+        self.faqmatches = FAQMatches(self.client)
+        self.inbounds_ud = InboundsUD(self.client)
+        self.urgency_rules = UrgencyRules(self.client)

--- a/rdw_ingestion_tools/api/aaq/main.py
+++ b/rdw_ingestion_tools/api/aaq/main.py
@@ -13,7 +13,7 @@ from . import client as default_client
 class pyAAQ:
     """A wrapper class for the various AAQ endpoints.
 
-    The client is configurable to it can be switched out in tests.
+    The client is configurable so it can be switched out in tests.
 
     """
 

--- a/rdw_ingestion_tools/api/aaqv2/main.py
+++ b/rdw_ingestion_tools/api/aaqv2/main.py
@@ -19,10 +19,10 @@ class pyAAQV2:
 
     client: Client = field(factory=lambda: default_client)
 
-    contents = field(init=False)
-    urgency_rules = field(init=False)
-    urgency_queries = field(init=False)
-    queries = field(init=False)
+    contents: Contents = field(init=False)
+    urgency_rules: UrgencyRules = field(init=False)
+    urgency_queries: UrgencyQueries = field(init=False)
+    queries: Queries = field(init=False)
 
     def __attrs_post_init__(self):
         self.contents = Contents(self.client)

--- a/rdw_ingestion_tools/api/aaqv2/main.py
+++ b/rdw_ingestion_tools/api/aaqv2/main.py
@@ -13,7 +13,7 @@ from . import client as default_client
 class pyAAQV2:
     """A wrapper class for the various AAQ V2 endpoints.
 
-    The client is configurable to it can be switched out in tests.
+    The client is configurable so it can be switched out in tests.
 
     """
 

--- a/rdw_ingestion_tools/api/content_repo/main.py
+++ b/rdw_ingestion_tools/api/content_repo/main.py
@@ -17,8 +17,8 @@ class pyContent:
 
     client: Client = field(factory=lambda: default_client)
 
-    pageviews = field(init=False)
-    pages = field(init=False)
+    pageviews: PageViews = field(init=False)
+    pages: Pages = field(init=False)
 
     def __attrs_post_init__(self):
         self.pageviews = PageViews(client=self.client)

--- a/rdw_ingestion_tools/api/content_repo/main.py
+++ b/rdw_ingestion_tools/api/content_repo/main.py
@@ -1,11 +1,25 @@
+from attrs import define, field
+from httpx import Client
+
 from api.content_repo.requests.page_views import PageViews
 from api.content_repo.requests.pages import Pages
 
-from . import client
+from . import client as default_client
 
 
+@define
 class pyContent:
-    """A wrapper class for the various Content Repo endpoints."""
+    """A wrapper class for the various Content Repo endpoints.
 
-    pageviews = PageViews(client)
-    pages = Pages(client)
+    The client is configurable to it can be switched out in tests.
+
+    """
+
+    client: Client = field(factory=lambda: default_client)
+
+    pageviews = field(init=False)
+    pages = field(init=False)
+
+    def __attrs_post_init__(self):
+        self.pageviews = PageViews(client=self.client)
+        self.pages = Pages(client=self.client)

--- a/rdw_ingestion_tools/api/flow_results/main.py
+++ b/rdw_ingestion_tools/api/flow_results/main.py
@@ -17,8 +17,8 @@ class pyFlows:
 
     client: Client = field(factory=lambda: default_client)
 
-    flows = field(init=False)
-    responses = field(init=False)
+    flows: Flows = field(init=False)
+    responses: Responses = field(init=False)
 
     def __attrs_post_init__(self):
         self.flows = Flows(client=self.client)

--- a/rdw_ingestion_tools/api/flow_results/main.py
+++ b/rdw_ingestion_tools/api/flow_results/main.py
@@ -1,11 +1,11 @@
+from attrs import define, field
+from httpx import Client
+
 from api.flow_results.requests.flows import Flows
 from api.flow_results.requests.responses import Responses
 
 from . import client as default_client
 
-from httpx import Client
-
-from attrs import define, field
 
 @define
 class pyFlows:

--- a/rdw_ingestion_tools/api/flow_results/main.py
+++ b/rdw_ingestion_tools/api/flow_results/main.py
@@ -1,11 +1,25 @@
 from api.flow_results.requests.flows import Flows
 from api.flow_results.requests.responses import Responses
 
-from . import client
+from . import client as default_client
 
+from httpx import Client
 
+from attrs import define, field
+
+@define
 class pyFlows:
-    """A wrapper class for the various Flow Results endpoints."""
+    """A wrapper class for the various Flow Results endpoints.
 
-    flows = Flows(client)
-    responses = Responses(client)
+    The client is configurable so it can be switched out in tests.
+
+    """
+
+    client: Client = field(factory=lambda: default_client)
+
+    flows = field(init=False)
+    responses = field(init=False)
+
+    def __attrs_post_init__(self):
+        self.flows = Flows(client=self.client)
+        self.responses = Responses(client=self.client)

--- a/rdw_ingestion_tools/api/rapidpro/main.py
+++ b/rdw_ingestion_tools/api/rapidpro/main.py
@@ -21,12 +21,12 @@ class pyRapid:
 
     client: Client = field(factory=lambda: default_client)
 
-    contacts = field(init=False)
-    fields = field(init=False)
-    flow_starts = field(init=False)
-    flows = field(init=False)
-    groups = field(init=False)
-    runs = field(init=False)
+    contacts: Contacts = field(init=False)
+    fields: Fields = field(init=False)
+    flow_starts: FlowStarts = field(init=False)
+    flows: Flows = field(init=False)
+    groups: Groups = field(init=False)
+    runs: Runs = field(init=False)
 
     def __attrs_post_init__(self):
         self.contacts = Contacts(client=self.client)

--- a/rdw_ingestion_tools/api/rapidpro/main.py
+++ b/rdw_ingestion_tools/api/rapidpro/main.py
@@ -13,7 +13,11 @@ from . import client as default_client
 
 @define
 class pyRapid:
-    """A wrapper class for the various Rapidpro endpoints."""
+    """A wrapper class for the various Rapidpro endpoints.
+
+    The client is configurable so that it can be switched out in tests.
+
+    """
 
     client: Client = field(factory=lambda: default_client)
 

--- a/rdw_ingestion_tools/api/rapidpro/main.py
+++ b/rdw_ingestion_tools/api/rapidpro/main.py
@@ -1,3 +1,6 @@
+from attrs import define, field
+from httpx import Client
+
 from api.rapidpro.requests.contacts import Contacts
 from api.rapidpro.requests.fields import Fields
 from api.rapidpro.requests.flow_starts import FlowStarts
@@ -5,15 +8,26 @@ from api.rapidpro.requests.flows import Flows
 from api.rapidpro.requests.groups import Groups
 from api.rapidpro.requests.runs import Runs
 
-from . import client
+from . import client as default_client
 
 
+@define
 class pyRapid:
     """A wrapper class for the various Rapidpro endpoints."""
 
-    contacts = Contacts(client)
-    fields = Fields(client)
-    flow_starts = FlowStarts(client)
-    flows = Flows(client)
-    groups = Groups(client)
-    runs = Runs(client)
+    client: Client = field(factory=lambda: default_client)
+
+    contacts = field(init=False)
+    fields = field(init=False)
+    flow_starts = field(init=False)
+    flows = field(init=False)
+    groups = field(init=False)
+    runs = field(init=False)
+
+    def __attrs_post_init__(self):
+        self.contacts = Contacts(client=self.client)
+        self.fields = Fields(client=self.client)
+        self.flow_starts = FlowStarts(client=self.client)
+        self.flows = Flows(client=self.client)
+        self.groups = Groups(client=self.client)
+        self.runs = Runs(client=self.client)

--- a/rdw_ingestion_tools/api/turn_bq/main.py
+++ b/rdw_ingestion_tools/api/turn_bq/main.py
@@ -1,3 +1,6 @@
+from attrs import define, field
+from httpx import Client
+
 from api.turn_bq.requests.cards import Cards
 from api.turn_bq.requests.chats import Chats
 from api.turn_bq.requests.contacts import Contacts
@@ -8,16 +11,32 @@ from api.turn_bq.requests.flow_results_data_packages import (
 from api.turn_bq.requests.messages import Messages
 from api.turn_bq.requests.statuses import Statuses
 
-from . import client
+from . import client as default_client
 
 
+@define
 class pyTurnBQ:
-    """ """
+    """A wrapper class for the various Turn BQ endpoints.
 
-    cards = Cards(client)
-    contacts = Contacts(client)
-    chats = Chats(client)
-    messages = Messages(client)
-    flow_results_data_packages = FlowResultsDataPackages(client)
-    flow_results = FlowResults(client)
-    statuses = Statuses(client)
+    The client is configurable so that it can be switched out in tests.
+
+    """
+
+    client: Client = field(factory=lambda: default_client)
+
+    cards = field(init=False)
+    contacts = field(init=False)
+    chats = field(init=False)
+    messages = field(init=False)
+    flow_results_data_packages = field(init=False)
+    flow_results = field(init=False)
+    statuses = field(init=False)
+
+    def __attrs_post_init__(self):
+        self.cards = Cards(client=self.client)
+        self.contacts = Contacts(client=self.client)
+        self.chats = Chats(client=self.client)
+        self.messages = Messages(client=self.client)
+        self.flow_results_data_packages = FlowResultsDataPackages(client=self.client)
+        self.flow_results = FlowResults(client=self.client)
+        self.statuses = Statuses(client=self.client)

--- a/rdw_ingestion_tools/api/turn_bq/main.py
+++ b/rdw_ingestion_tools/api/turn_bq/main.py
@@ -24,13 +24,13 @@ class pyTurnBQ:
 
     client: Client = field(factory=lambda: default_client)
 
-    cards = field(init=False)
-    contacts = field(init=False)
-    chats = field(init=False)
-    messages = field(init=False)
-    flow_results_data_packages = field(init=False)
-    flow_results = field(init=False)
-    statuses = field(init=False)
+    cards: Cards = field(init=False)
+    contacts: Contacts = field(init=False)
+    chats: Chats = field(init=False)
+    messages: Messages = field(init=False)
+    flow_results_data_packages: FlowResultsDataPackages = field(init=False)
+    flow_results: FlowResults = field(init=False)
+    statuses: Statuses = field(init=False)
 
     def __attrs_post_init__(self):
         self.cards = Cards(client=self.client)


### PR DESCRIPTION
# Description

For the longest time this library was untested. This is partly due to capacity constraints and partly due to the fact that writing fakes for every third party API while they make changes every 2nd week is a maintenance burden we would be unable to shoulder.

This is changing! We have a modicum of stability in `turn_bq` and `content_repo` (soon). We've got tests for `aaqv2` and might consider the same for `flow_results`. The rest we should consider marking for deprecation.

This PR simply changes how we specify a client in the wrapper class to follow what's done in `aaqv2` in all other submodules. This will allow us to eventually inject a fake client to test against.

- [x] aaq
- [x] aaqv2
- [x] content_repo
- [x] flow_results
- [x] mqr [DEPRECATE IN OTHER PR]
- [x] rapidpro
- [x] turn [DEPRECATE IN OTHER PR]
- [x] turn_bq
