### PR TITLE
Add start_date and end_date arguments to aaqv2 methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,6 @@ pyS3.s3.get_filenames(bucket=bucket, prefix=prefix)
 1. `uv sync`
 2. `uv run --env-file .env examples/{path}` e.g. `uv run --env-file .env examples/turn_bq/cards.py`
 
-## to-do
-
-- Add tests - yes, I am a bad developer for not having any yet.
+#### Running tests
+1. `uv sync --dev`
+2. `uv run pytest -vv --cov`

--- a/rdw_ingestion_tools/api/aaqv2/requests/queries.py
+++ b/rdw_ingestion_tools/api/aaqv2/requests/queries.py
@@ -11,7 +11,7 @@ class Queries:
 
     client: Client
 
-    def get_queries(self, **kwargs: str | int) -> DataFrame:
+    def get_queries(self, start_date: str, end_date: str) -> DataFrame:
         """Get a pandas DataFrame of queries.
 
         This endpoint supports time-based query parameters which can
@@ -26,6 +26,11 @@ class Queries:
 
         url = "queries"
 
-        queries_generator = get(self.client, url, **kwargs)
+        params = {
+            "start_date": start_date,
+            "end_date": end_date,
+        }
+
+        queries_generator = get(self.client, url, **params)
 
         return DataFrame(queries_generator)

--- a/rdw_ingestion_tools/api/aaqv2/requests/queries.py
+++ b/rdw_ingestion_tools/api/aaqv2/requests/queries.py
@@ -11,7 +11,9 @@ class Queries:
 
     client: Client
 
-    def get_queries(self, start_date: str, end_date: str) -> DataFrame:
+    def get_queries(
+        self, start_date: str, end_date: str, **kwargs: str | int
+    ) -> DataFrame:
         """Get a pandas DataFrame of queries.
 
         This endpoint supports time-based query parameters which can
@@ -29,6 +31,7 @@ class Queries:
         params = {
             "start_date": start_date,
             "end_date": end_date,
+            **kwargs,
         }
 
         queries_generator = get(self.client, url, **params)

--- a/rdw_ingestion_tools/api/aaqv2/requests/urgency_queries.py
+++ b/rdw_ingestion_tools/api/aaqv2/requests/urgency_queries.py
@@ -14,7 +14,7 @@ class UrgencyQueries:
 
     client: Client
 
-    def get_urgency_queries(self, **kwargs: str | int) -> DataFrame:
+    def get_urgency_queries(self, start_date: str, end_date: str) -> DataFrame:
         """Get a pandas DataFrame of urgency queries.
 
         This endpoint supports time-based query parameters which can
@@ -29,6 +29,11 @@ class UrgencyQueries:
 
         url = "urgency-queries"
 
-        urgency_queries_generator = get(self.client, url, **kwargs)
+        params = {
+            "start_date": start_date,
+            "end_date": end_date,
+        }
+
+        urgency_queries_generator = get(self.client, url, **params)
 
         return DataFrame(urgency_queries_generator)

--- a/rdw_ingestion_tools/api/aaqv2/requests/urgency_queries.py
+++ b/rdw_ingestion_tools/api/aaqv2/requests/urgency_queries.py
@@ -14,7 +14,9 @@ class UrgencyQueries:
 
     client: Client
 
-    def get_urgency_queries(self, start_date: str, end_date: str) -> DataFrame:
+    def get_urgency_queries(
+        self, start_date: str, end_date: str, **kwargs: str | int
+    ) -> DataFrame:
         """Get a pandas DataFrame of urgency queries.
 
         This endpoint supports time-based query parameters which can
@@ -32,6 +34,7 @@ class UrgencyQueries:
         params = {
             "start_date": start_date,
             "end_date": end_date,
+            **kwargs,
         }
 
         urgency_queries_generator = get(self.client, url, **params)

--- a/uv.lock
+++ b/uv.lock
@@ -602,7 +602,7 @@ wheels = [
 
 [[package]]
 name = "rdw-ingestion-tools"
-version = "1.0.6.dev0"
+version = "2.0.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
From the ingestion pipeline, we call the get methods without named arguments:

`df = ingestion_method(start_time.isoformat(), end_time.isoformat())`

Currently, the aaqv2 methods need to be called with named arguments:

`pyAAQV2().queries.get_queries(start_date=start_date, end_date=end_date)`

While the Turn BQ methods do not. This change updates the aaqv2 get methods to use the same argument structure as the Turn BQ methods. 
