### PR TITLE
Reduce concat operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <img src="https://github.com/praekeltfoundation/rdw-ingestion-tools/workflows/lint/badge.svg" width="120" />
     <img src="https://github.com/praekeltfoundation/rdw-ingestion-tools/workflows/release/badge.svg" width="145" />
     <img src="https://github.com/praekeltfoundation/rdw-ingestion-tools/workflows/test/badge.svg" width="120" />
-    <img src="https://img.shields.io/badge/version-2.0.6.dev0-orange" width="145" />
+    <img src="https://img.shields.io/badge/version-2.0.6-orange" width="145" />
     <img src="https://img.shields.io/badge/license-MIT-blue" width="100" />
   </p>
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rdw-ingestion-tools"
-version = "2.0.6.dev0"
+version = "2.0.6"
 description = "A Python package for integrating third-party data to Reach Digital Health's AWS Data Lake."
 authors = [
     {name = "Schalk <schalk@reachdigitalhealth.org>"},

--- a/rdw_ingestion_tools/api/__init__.py
+++ b/rdw_ingestion_tools/api/__init__.py
@@ -114,8 +114,4 @@ def concatenate_to_string_lazyframe(
         )
         lfs.append(response_lf)
 
-    if lfs:
-        lf = concat(lfs, how="diagonal")
-        return lf
-    else:
-        return LazyFrame()
+    return concat(lfs, how="diagonal") if lfs else LazyFrame()

--- a/rdw_ingestion_tools/api/__init__.py
+++ b/rdw_ingestion_tools/api/__init__.py
@@ -101,7 +101,7 @@ def concatenate_to_string_lazyframe(
     """
     Flattens JSON data. Returns a LazyFrame with columns of type `String`.
     """
-    lf = LazyFrame()
+    lfs = []
 
     for data in chunked(objs, batch_size):
         schema = get_polars_schema(data=data, object_columns=object_columns)
@@ -112,6 +112,10 @@ def concatenate_to_string_lazyframe(
                 col(Object).map_elements(lambda x: str(x), return_dtype=String)
             )
         )
-        lf = concat([lf, response_lf], how="diagonal")
+        lfs.append(response_lf)
 
-    return lf
+    if lfs:
+        lf = concat(lfs, how="diagonal")
+        return lf
+    else:
+        return LazyFrame()

--- a/uv.lock
+++ b/uv.lock
@@ -649,7 +649,7 @@ wheels = [
 
 [[package]]
 name = "rdw-ingestion-tools"
-version = "2.0.6.dev0"
+version = "2.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
# Description 
This is an effort to reduce the memory overhead and silent failures while LazyFrames are being created. Moving the concat operation outside of the loop allows Polars to build one logical plan all at once. 

Pipelines run locally have benefitted from this change. 